### PR TITLE
Allow overriding command to message_template.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ from ritdu_slacker.api import SlackClient
 client = SlackClient()
 client.post_message("via python api","ringier-southafrica","#pe-alerts")
 {'message_uuid': '9890b802-fac3-4e61-bbe8-b53cc17fc581', 'message_ts': '1677473299.255969', 'thread_uuid': '9890b802-fac3-4e61-bbe8-b53cc17fc581', 'thread_ts': '1677473299.255969', 'channel': 'CV3JFH08J'}
+client.post_message(datajson,"ringier-southafrica","pe-test",command="SlackJson")
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ To send a message and file to a thread in a slack channel:
 ```bash
 $ ritdu-slacker file --workspace "${SLACK_WORKSPACE}" --channel "${SLACK_CHANNEL//#}" --text "Oops!" --file "/tmp/errorlog.txt" --thread-uuid "${thread_uuid}"
 ```
+To send a jsonblob to slack:
+```bash
+$ ritdu-slacker message --text  '{ "blocks": [ { "type": "section", "text": { "type": "mrkdwn", "text": "Hello, Assistant to the Regional Manager Dwight! *Michael Scott* wants to know where youd like to take the Paper Company investors to dinner tonight.\n\n *Please select a restaurant:*" } }, { "type": "divider" }, { "type": "section", "text": { "type": "mrkdwn", "text": "*Farmhouse aThai Cuisine*\n:star::star::star::star: 1528 reviews\n They do have some vegan options, like the roti and curry, plus they have a ton of salad stuff and noodles can be ordered without meat!! They have something for everyone here" }, "accessory": { "type": "image", "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/c7ed05m9lC2EmA3Aruue7A/o.jpg", "alt_text": "alt text for image" } }, { "type": "section", "text": { "type": "mrkdwn", "text": "*Kin Khao*\n:star::star::star::star: 1638 reviews\n The sticky rice also goes wonderfully with the caramelized pork belly, which is absolutely melt-in-your-mouth and so soft." }, "accessory": { "type": "image", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/korel-1YjNtFtJlMTaC26A/o.jpg", "alt_text": "alt text for image" } }, { "type": "section", "text": { "type": "mrkdwn", "text": "*Ler Ros*\n:star::star::star::star: 2082 reviews\n I would really recommend the  Yum Koh Moo Yang - Spicy lime dressing and roasted quick marinated pork shoulder, basil leaves, chili & rice powder." }, "accessory": { "type": "image", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/DawwNigKJ2ckPeDeDM7jAg/o.jpg", "alt_text": "alt text for image" } }, { "type": "divider" } ] }' --command 'SlackJson' --workspace "ringier-southafrica" --channel "pe-test"
+```
 
 ### Python
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ritdu-slacker"
-version = "1.3.3"
+version = "1.3.4"
 description = "Simple internal Slack API wrapper"
 authors = [
     "Ringier Tech <tools@ringier.co.za>",

--- a/ritdu_slacker/api.py
+++ b/ritdu_slacker/api.py
@@ -2,6 +2,7 @@ from requests import Session
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
+
 class SlackClient:
     def __init__(self, retries=5, backoff_factor=0.5, status_forcelist=(500, 502, 504)):
         self.retries = retries
@@ -34,7 +35,7 @@ class SlackClient:
         fallback = text
         # fallback_message cannot be a dict, set to blank str if we detect SlackJson
         if command == "SlackJson":
-          fallback = "Error sending json, fallback string stub."
+            fallback = "Error sending json, fallback string stub."
 
         data = {
             "command": command,

--- a/ritdu_slacker/api.py
+++ b/ritdu_slacker/api.py
@@ -25,6 +25,7 @@ class SlackClient:
         text,
         workspace,
         channel,
+        command="SimpleMessage",
         thread_uuid=None,
         message_uuid=None,
         message_or_thread_uuid=None,
@@ -32,7 +33,7 @@ class SlackClient:
     ):
         url = "https://slacker.cube-services.net/api/message-template"
         data = {
-            "command": "SimpleMessage",
+            "command": command,
             "workspace": workspace,
             "channel": channel,
             "message_uuid": message_uuid,

--- a/ritdu_slacker/api.py
+++ b/ritdu_slacker/api.py
@@ -2,7 +2,6 @@ from requests import Session
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
-
 class SlackClient:
     def __init__(self, retries=5, backoff_factor=0.5, status_forcelist=(500, 502, 504)):
         self.retries = retries
@@ -32,6 +31,11 @@ class SlackClient:
         thread_broadcast=False,
     ):
         url = "https://slacker.cube-services.net/api/message-template"
+        fallback = text
+        # fallback_message cannot be a dict, set to blank str if we detect SlackJson
+        if command == "SlackJson":
+          fallback = "Error sending json, fallback string stub."
+
         data = {
             "command": command,
             "workspace": workspace,
@@ -41,7 +45,7 @@ class SlackClient:
             "message_or_thread_uuid": message_or_thread_uuid,
             "thread_broadcast": thread_broadcast,
             "message": text,
-            "fallback_message": text,
+            "fallback_message": fallback,
         }
         response = self.session.post(url=url, json=data, timeout=(10, 10)).json()
         return response

--- a/ritdu_slacker/cli.py
+++ b/ritdu_slacker/cli.py
@@ -35,7 +35,11 @@ class SlackMessageCLI:
         "--channel", "-c", default=None, required=True, help="slack channel name"
     )
     @click.option(
-        "--command", "-C", default="SimpleMessage", required=False, help="SimpleMessage|SlackJson"
+        "--command",
+        "-C",
+        default="SimpleMessage",
+        required=False,
+        help="SimpleMessage|SlackJson",
     )
     @click.option(
         "--message-uuid",
@@ -76,9 +80,9 @@ class SlackMessageCLI:
     ):
         sender = get_client()
         if command == "SlackJson":
-          text = json.loads(text)
+            text = json.loads(text)
         else:
-          text = f"{text}"
+            text = f"{text}"
         result = sender.post_message(
             text=text,
             thread_uuid=thread_uuid if thread_uuid else "",

--- a/ritdu_slacker/cli.py
+++ b/ritdu_slacker/cli.py
@@ -35,6 +35,9 @@ class SlackMessageCLI:
         "--channel", "-c", default=None, required=True, help="slack channel name"
     )
     @click.option(
+        "--command", "-C", default="SimpleMessage", required=False, help="SimpleMessage|SlackJson"
+    )
+    @click.option(
         "--message-uuid",
         "-u",
         default=None,
@@ -67,6 +70,7 @@ class SlackMessageCLI:
         message_uuid,
         message_or_thread_uuid,
         workspace,
+        command,
         channel,
         thread_broadcast,
     ):
@@ -79,6 +83,7 @@ class SlackMessageCLI:
             if message_or_thread_uuid
             else "",
             workspace=workspace,
+            command=command,
             channel=channel,
             thread_broadcast=thread_broadcast,
         )

--- a/ritdu_slacker/cli.py
+++ b/ritdu_slacker/cli.py
@@ -75,8 +75,12 @@ class SlackMessageCLI:
         thread_broadcast,
     ):
         sender = get_client()
+        if command == "SlackJson":
+          text = json.loads(text)
+        else:
+          text = f"{text}"
         result = sender.post_message(
-            text=f"{text}",
+            text=text,
             thread_uuid=thread_uuid if thread_uuid else "",
             message_uuid=message_uuid if message_uuid else "",
             message_or_thread_uuid=message_or_thread_uuid


### PR DESCRIPTION
We could then start posting rawjson if we wanted as per:

```
curl -H "Accept: application/json" -X POST 'https://fw-slacker.test/api/message-template' --data '{"command": "SlackJson","channel": "UV60NRPDX","project": "ritdu-horizon","message": {"blocks":[{"type":"section","text":```
